### PR TITLE
Update StrategyManager.h

### DIFF
--- a/BasicBot/BasicBot/StrategyManager.h
+++ b/BasicBot/BasicBot/StrategyManager.h
@@ -25,11 +25,13 @@ namespace MyBot
 			Bionic,
 			Bionic_Tank,
 			Mechanic,
-			One_Fac_Multi,
+			One_Fac_Vulture,
+			One_Fac_Tank,
 			Two_Fac,
 			Mechanic_Goliath,
 			Mechanic_Vessel,
-			Defence
+			BSB,
+			BBS
 		};
 
 		main_strategies next_strategy;
@@ -88,5 +90,7 @@ namespace MyBot
 		BuildOrderItem::SeedPositionStrategy getBuildSeedPositionStrategy(MetaType type);
 		int getUnitLimit(MetaType type);
 		double weightByFrame(double max_weight);
+
+		Strategy::main_strategies getMainStrategy();
 	};
 }


### PR DESCRIPTION
defence 모드를 두개로 분리
bbs : barrack -> barrack -> supply 
bsb: barrack -> supply -> barrack

- one_fac_vulture
질럿 찌르기 방어용 supply -> barrack -> refinery 순
질럿 봇 상대로 멀면 이기고 가까우면 지는 추세
나중에 one_fac_tank와 같이 수정가능

- one_fac_tank
드래군 찌르기 방어용, barrack -> refinery -> supply 순
알버타 상대로 가까우면 지고 멀면 이기는 추세
